### PR TITLE
feat: button component 추가 및 적용

### DIFF
--- a/app/components/button.tsx
+++ b/app/components/button.tsx
@@ -1,0 +1,54 @@
+import { css } from "@emotion/react";
+import React from "react";
+import { Link } from "@remix-run/react";
+
+type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  buttonType?: "primary" | "secondary";
+  as?: "button" | "link";
+  to?: string;
+};
+
+export const Button = ({ buttonType = "primary", children, as = "button", to, ...props }: Props) => {
+  const getButtonStyles = () => {
+    switch (buttonType) {
+      case "primary":
+        return primaryCss;
+      case "secondary":
+        return secondaryCss;
+      default:
+        return primaryCss;
+    }
+  };
+
+  if (as === "link") {
+    return (
+      <Link to={to!} css={[baseButtonCss, getButtonStyles()]}>
+        {children}
+      </Link>
+    );
+  }
+  return (
+    <button css={[baseButtonCss, getButtonStyles()]} {...props}>
+      {children}
+    </button>
+  );
+};
+
+// 기본 스타일
+const baseButtonCss = css`
+  width: 100%;
+  text-align: center;
+  border-radius: 8px;
+  padding: 16px 0;
+  font-size: 14px;
+`;
+
+const primaryCss = css`
+  color: white;
+  background-color: #151528;
+`;
+
+const secondaryCss = css`
+  color: #151528;
+  background-color: #c1c1c1;
+`;

--- a/app/components/text-area.tsx
+++ b/app/components/text-area.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import { Dispatch, Fragment, SetStateAction } from "react";
 
-type textareaProps = {
+type Props = {
   limit: number;
   currentLength: number;
   onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
@@ -18,7 +18,7 @@ export const Textarea = ({
   height,
   setHeight,
   ...props
-}: textareaProps) => {
+}: Props) => {
   const LIMIT = limit;
 
   return (

--- a/app/routes/result_.card.tsx
+++ b/app/routes/result_.card.tsx
@@ -1,7 +1,8 @@
 import { css } from "@emotion/react";
-import { Link, useNavigate } from "@remix-run/react";
+import { useNavigate } from "@remix-run/react";
 import { ArrowLeft } from "public/icons/Arrow";
 import { useState } from "react";
+import { Button } from "~/components/button";
 import { FloatingBottomArea } from "~/components/floating-bottom-area";
 
 export default function Page() {
@@ -40,14 +41,14 @@ export default function Page() {
       </div>
 
       <FloatingBottomArea>
-        <div css={buttons.wrapperCss}>
+        <div css={buttonWrapper}>
           {/* NOTE: 베타테스트 버튼 */}
-          <Link to={"/result/feedback"} css={buttons.shareButtonCss}>
+          <Button as="link" to="/result/feedback">
             베타테스트 후기 남기기
-          </Link>
+          </Button>
 
-          {/* <button css={buttons.downloadButtonCss}>카드 다운로드</button>
-        <button css={buttons.shareButtonCss}>결과 공유하기</button> */}
+          {/* <Button buttonType="secondary">카드 다운로드</Button>
+          <Button>결과 공유하기</Button> */}
         </div>
       </FloatingBottomArea>
     </>
@@ -128,31 +129,10 @@ const underlineCss = css`
   }
 `;
 
-const buttons = {
-  wrapperCss: css`
-    width: 100%;
+const buttonWrapper = css`
+  width: 100%;
 
-    display: flex;
-    gap: 10px;
-    justify-content: center;
-
-    > button,
-    a {
-      width: 100%;
-      text-align: center;
-      border-radius: 8px;
-      padding: 16px 0;
-      font-size: 14px;
-    }
-  `,
-
-  downloadButtonCss: css`
-    color: #151528;
-    background-color: #c1c1c1;
-  `,
-
-  shareButtonCss: css`
-    color: white;
-    background-color: #151528;
-  `,
-};
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+`;

--- a/app/routes/result_.feedback-complete.tsx
+++ b/app/routes/result_.feedback-complete.tsx
@@ -1,0 +1,47 @@
+import { css } from "@emotion/react";
+import { Button } from "~/components/button";
+import { FloatingBottomArea } from "~/components/floating-bottom-area";
+
+export default function Page() {
+  return (
+    <>
+      <div css={containerCss}>
+        <p>
+          새해맞이
+          <br />
+          달토끼 구출 대작전
+          <br />
+          베타테스트에 참가해주셔서
+          <br />
+          감사합니다!:)
+          <br />
+          <br />
+          새해에 완성된 서비스로 찾아올게요!
+        </p>
+      </div>
+
+      <FloatingBottomArea>
+        <Button as="link" to="/">
+          처음으로
+        </Button>
+      </FloatingBottomArea>
+    </>
+  );
+}
+
+const containerCss = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 32px;
+
+  height: calc(100dvh - 100px);
+  padding: 64px 24px 32px 24px;
+  text-align: center;
+
+  > h1 {
+    font-size: 20px;
+    text-align: center;
+    margin-top: 12px;
+  }
+`;

--- a/app/routes/result_.feedback.tsx
+++ b/app/routes/result_.feedback.tsx
@@ -2,6 +2,7 @@ import { css } from "@emotion/react";
 import { useNavigate } from "@remix-run/react";
 import { ArrowLeft } from "public/icons/Arrow";
 import { useState } from "react";
+import { Button } from "~/components/button";
 import { FloatingBottomArea } from "~/components/floating-bottom-area";
 import { Textarea } from "~/components/text-area";
 
@@ -28,6 +29,11 @@ export default function Page() {
       ...prev,
       [type]: value,
     }));
+  };
+
+  // NOTE: api 연동
+  const handleSubmit = () => {
+    navigate("/result/feedback-complete");
   };
 
   return (
@@ -101,9 +107,7 @@ export default function Page() {
       </div>
 
       <FloatingBottomArea>
-        <div css={buttons.wrapperCss}>
-          <button css={buttons.submitButtonCss}>제출하기</button>
-        </div>
+        <Button onClick={handleSubmit}>제출하기</Button>
       </FloatingBottomArea>
     </>
   );
@@ -150,28 +154,5 @@ const feedbacks = {
 
   headlineCss: css`
     font-size: 16px;
-  `,
-};
-
-const buttons = {
-  wrapperCss: css`
-    width: 100%;
-
-    display: flex;
-    gap: 10px;
-    justify-content: center;
-
-    > button {
-      width: 100%;
-      text-align: center;
-      border-radius: 8px;
-      padding: 16px 0;
-      font-size: 14px;
-    }
-  `,
-
-  submitButtonCss: css`
-    color: white;
-    background-color: #151528;
   `,
 };


### PR DESCRIPTION
## 작업내용

- button componen를 추가합니다.
- 페이지에 적용합니다.
    - feedback-complete page를 추가합니다 

### button component
1. buttonType으로 스타일을 고를 수 있습니다.
    - primary
    <img width="372" alt="스크린샷 2024-12-26 오후 10 43 08" src="https://github.com/user-attachments/assets/10680531-e5bb-47cd-88c1-4d883ea4367b" />



    - secondary
    <img width="368" alt="스크린샷 2024-12-26 오후 10 43 35" src="https://github.com/user-attachments/assets/2bcb8d4d-b6c9-4e9e-a04b-e599fa47e77e" />


2. as props로 Link, button tag를 고를 수 있습니다.