### PR TITLE
feat: 게임 결과 페이지에서 사용될 api 추가 및 연동 (v1/card)

### DIFF
--- a/app/components/loading.tsx
+++ b/app/components/loading.tsx
@@ -17,7 +17,7 @@ export default function Loading() {
   return (
     <div css={containerCss}>
       <div>
-        <img src={`/illusts/${images[current]}_right.PNG`} css={imageCss} />
+        <img src={`/illusts/${images[current]}_right.PNG`} css={imageCss} alt="loading" />
         <p>
           {/** TODO: 사용자가 입력한 이름 활용한 멘트로 변경 */}
           지금까지 찾아준 것들로 단장중이야

--- a/app/constants/result.ts
+++ b/app/constants/result.ts
@@ -1,8 +1,9 @@
-export const GAME_RESULT: {
-  [key: string]: {
-    title: string;
-    description: string;
-  };
+export type gameResultContent = {
+  title: string;
+  description: string;
+}
+export const GAME_RESULT_CONTENT: {
+  [key: string]: gameResultContent;
 } = {
   "0000": {
     title: "모든걸 잃어버린 달토끼",

--- a/app/hooks/apis/useGetPlayerGameInfos.ts
+++ b/app/hooks/apis/useGetPlayerGameInfos.ts
@@ -1,0 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "~/api";
+
+type Req = {
+  id: string;
+};
+type Res = {
+  USERNAME: string;
+  CARD_MESSAGE: string;
+  RESULT: string;
+}
+export const useGetPlayerGameInfos = (req: Req) => {
+  const getPlayerGameInfos = async ({ id }: Req) => {
+    const res: Res = await api.get(`/v1/card/${id}`);
+    return res;
+  };
+
+  return useQuery({
+    queryKey: ["playerNames", req.id],
+    queryFn: () => getPlayerGameInfos(req),
+  });
+};

--- a/app/hooks/apis/usePostNickname.ts
+++ b/app/hooks/apis/usePostNickname.ts
@@ -3,10 +3,15 @@ import { api } from "~/api";
 
 type Req = {
   username: string;
+  message: string;
+  game_result: string;
 };
+type Res = {
+  id: string;
+}
 export const usePostNickname = () => {
   const postNickname = async (req: Req) => {
-    const res = await api.post(`/v1/card`, req);
+    const res: Res = await api.post(`/v1/card`, req);
     return res;
   };
 

--- a/app/routes/rabbit-card_.$rabbit.tsx
+++ b/app/routes/rabbit-card_.$rabbit.tsx
@@ -1,25 +1,38 @@
 import { css } from "@emotion/react";
 import { useParams } from "@remix-run/react";
+import { useEffect, useState } from "react";
 import { Button } from "~/components/button";
-import { GAME_RESULT } from "~/constants/result";
-import { decrypt } from "~/utils/crypto";
+import { GAME_RESULT_CONTENT, gameResultContent } from "~/constants/result";
+import { useGetPlayerGameInfos } from "~/hooks/apis/useGetPlayerGameInfos";
 
 export default function Page() {
-  const { rabbit } = useParams();
-  const decryptRabbit = decrypt(rabbit ?? "") ?? "";
-  const resultText = GAME_RESULT[decryptRabbit] ?? GAME_RESULT["0000"];
+  const { rabbit = "" } = useParams();
+  const { data } = useGetPlayerGameInfos({ id: rabbit });
 
+  const [gameResult, setGameResult] = useState<{ image: string; text: gameResultContent }>();
+
+  useEffect(() => {
+    if (!data) return;
+
+    setGameResult({
+      image: data.RESULT,
+      text: GAME_RESULT_CONTENT[data?.RESULT],
+    });
+  }, [data]);
+
+  // NOTE: 로딩 표시?
+  if (!gameResult) return;
   return (
     <>
       <div
         css={containerCss}
         style={{
-          background: `#151528 url("/images/result/rabbit_${decryptRabbit}.png") center/cover no-repeat`,
+          background: `#151528 url("/images/result/rabbit_${gameResult.image}.png") center/cover no-repeat`,
         }}
       >
         <div css={textWrapperCss}>
-          <h1>{resultText.title}</h1>
-          <div>{resultText.description}</div>
+          <h1>{gameResult?.text.title}</h1>
+          <div>{gameResult?.text.description}</div>
         </div>
       </div>
 

--- a/app/routes/result_.$rabbit.tsx
+++ b/app/routes/result_.$rabbit.tsx
@@ -1,19 +1,13 @@
 import { css } from "@emotion/react";
 import { Link, useParams } from "@remix-run/react";
-import { useAtomValue } from "jotai";
 import { useEffect, useState } from "react";
 import { Button } from "~/components/button";
 import Loading from "~/components/loading";
-import { GAME_RESULT } from "~/constants/result";
-import { usePostNickname } from "~/hooks/apis/usePostNickname";
-import { nameAtom } from "~/utils/usePhaseActions";
+import { GAME_RESULT_CONTENT } from "~/constants/result";
 
 export default function Page() {
-  const username = useAtomValue(nameAtom);
-  const { mutate } = usePostNickname();
-
   const { rabbit = "0000" } = useParams();
-  const resultText = GAME_RESULT[rabbit];
+  const resultText = GAME_RESULT_CONTENT[rabbit];
 
   const [loading, setLoading] = useState(true);
 
@@ -23,14 +17,6 @@ export default function Page() {
     }, 3000);
     return () => clearTimeout(timer);
   }, []);
-
-  useEffect(() => {
-    if (!username) {
-      return;
-    }
-
-    mutate({ username });
-  }, [username]);
 
   if (loading) {
     return <Loading />;


### PR DESCRIPTION
## 📌 Summary
- 결과 페이지에서 사용될 api를 추가합니다.
    - `get card/v1/${id}` : id값을 기준으로 사용자의 이름, 메세지, 토끼 결과를 불러옵니다
    - `post card/v1` : 사용자의 이름, 메세지, 토끼 결과로 랜덤 id값을 받아옵니다.

<!-- PR에 대한 간단한 요약을 작성하세요 -->

## ✨ Changes

<!-- 변경된 내용을 작성해주세요 -->

- [x] api 추가
- [x] api 연동

## 📸 Screenshots

<!-- 필요하다면 스크린샷이나 관련 이미지를 첨부하세요 -->

## 🤔 Considerations

<!-- 리뷰어가 확인해야 할 주요 내용을 작성해주세요 -->

- CORS 에러 발생으로 console이 남아있습니다. (디버깅용)
