### PR TITLE
fix: #31 modify adSense script method

### DIFF
--- a/app/components/common/ad-sense-script.tsx
+++ b/app/components/common/ad-sense-script.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+
+export default function AdSenseScript() {
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7338574251336623";
+    script.async = true;
+    script.crossOrigin = "anonymous";
+    document.body.appendChild(script);
+
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  return null;
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -5,6 +5,7 @@ import "../style/global.css";
 import { QueryProvider } from "./providers/query-provider";
 import { PreventExternalBrowser } from "./components/common/prevent-external-browser";
 import { useEffect } from "react";
+import AdSenseScript from "./components/common/ad-sense-script";
 
 export const links: LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -57,7 +58,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <QueryProvider>{isRestrictedBrowser ? <PreventExternalBrowser /> : children}</QueryProvider>
         <ScrollRestoration />
         <Scripts />
-        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7338574251336623" crossOrigin="anonymous" />
+        <AdSenseScript />
       </body>
     </html>
   );


### PR DESCRIPTION
## 📌 Summary

- 애드센스 스크립트를 로드하는 방식을 수정했어요.

## ✨ Changes

<!-- 변경된 내용을 작성해주세요 -->

- [x] app/components/common/ad-sense-script.tsx
  - `Remix`에서 구글 애널리틱스 정적 삽입에 대한 스크립트 에러가 발생해요, 이를 동적으로 삽입하는 방식으로 변경했어요.